### PR TITLE
FEAT: Add ability to hide explore more section

### DIFF
--- a/code/web/interface/themes/responsive/Search/explore-more-bar.tpl
+++ b/code/web/interface/themes/responsive/Search/explore-more-bar.tpl
@@ -1,5 +1,6 @@
 {strip}
 	{* TODO: Consider renaming classes to assume they are under the exploreMoreBar class *}
+{if !empty($showExploreMoreOptions)}
 <div class="exploreMoreBar row">
 	{*<div class="label-left">*}
 	<div class="label-top">
@@ -50,5 +51,9 @@
 	</div>
 
 </div>
+{else}
+	<div>
+	</div>
+{/if}
 {/strip}
 

--- a/code/web/sys/DBMaintenance/version_updates/23.12.01.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.12.01.php
@@ -26,6 +26,13 @@ function getUpdates23_12_01(): array {
 			'sql' => [
 				'ALTER TABLE ip_lookup ADD COLUMN authenticatedForSummon TINYINT DEFAULT 0',
 			]
-			], //summon authentication
-    ];
+		], //summon authentication
+		'explore_more_section_control' => [
+			'title' => 'Explore More Section Control',
+			'description' => 'Allow control over whether the Explore More Section is displayed',
+			'sql' => [
+				"ALTER TABLE layout_settings ADD COLUMN showExploreMoreOptions TINYINT DEFAULT '1'",
+			]
+		],//control_whether_the_explore_more_box_is_displayed
+	];
 }

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -704,6 +704,7 @@ class UInterface extends Smarty {
 		$this->assign('showDisplayNameInHeader', $library->showDisplayNameInHeader);
 		$this->assign('externalMaterialsRequestUrl', $library->externalMaterialsRequestUrl);
 		$this->assign('languageAndDisplayInHeader', $library->languageAndDisplayInHeader);
+		$this->assign('showExploreMoreOptions', $library->getLayoutSettings()->showExploreMoreOptions);
 
 		if ($location != null) {
 			$this->assign('showDisplayNameInHeader', $location->showDisplayNameInHeader);

--- a/code/web/sys/Theming/LayoutSetting.php
+++ b/code/web/sys/Theming/LayoutSetting.php
@@ -16,6 +16,7 @@ class LayoutSetting extends DataObject {
 	public $showTopOfPageButton;
 	public $dismissPlacardButtonLocation;
 	public $dismissPlacardButtonIcon;
+	public $showExploreMoreOptions;
 	public $contrastRatio;
 
 	static function getObjectStructure($context = ''): array {
@@ -102,6 +103,13 @@ class LayoutSetting extends DataObject {
 				'label' => 'Show Dismiss Placard Button as <i class="fas fa-times"></i> (Close) Icon',
 				'description' => 'Whether or not to show icon instead of default dismiss placard text',
 				'default' => false,
+			],
+			'showExploreMoreOptions' => [
+				'property' => 'showExploreMoreOptions',
+				'type' => 'checkbox',
+				'label' => 'Show Explore More Options',
+				'description' => 'Whether or not to display the Explore More Options box.',
+				'default' => true,
 			],
 			'contrastRatio' => [
 				'property' => 'contrastRatio',


### PR DESCRIPTION
Test Plan:
1. Navigate to Theme and Layout -> Layout Settings.
2. Note that there is now a checkbox for 'Show Explore More Options.'
3. By default this is checked. 
4. Carry out a search and the explore more box will appear in the results.
5. Navigate back to the Layout Settings and uncheck the 'Show Explore More Options' box.
6. Repeat your search. The explore more options box will no longer be in your results. 