### PR TITLE
New Feat: Publication Date Filters

### DIFF
--- a/code/web/services/Summon/Results.php
+++ b/code/web/services/Summon/Results.php
@@ -71,8 +71,12 @@ class Summon_Results extends ResultsAction {
 		$interface->assign('filterList', $appliedFacets);
 		$limitList = $searchObject->getLimitList();
 		$interface->assign('limitList', $limitList);
-		$facetSet = $searchObject->getFacetSet();
+		$facetSetOne = $searchObject->getFacetSet();
+		$rangeFacetSet = $searchObject->getRangeFacetSet();
+		$interface->assign('sideRangeFacetSet', $rangeFacetSet);
+		$facetSet = array_merge($facetSetOne, $rangeFacetSet);
 		$interface->assign('sideFacetSet', $facetSet);
+
 
 		//Figure out which counts to show.
 		$facetCountsToShow = $library->getGroupedWorkDisplaySettings()->facetCountsToShow;


### PR DESCRIPTION
This patch adds a publication decade filter to the side facets for Summon
Test Plan:
1.Prior to applying the patch, set up a Summon Search and note the facet options on the left hand side. 
2.Apply the patch and repeat the search. Note that there is now the option to filter by publication decade. 
3.Use the publication decade filter and ensure that the results returned are reflective of the decade filter selected. 