### PR TITLE
fix: return to page one of resutls when filter applied

### DIFF
--- a/code/web/sys/SearchObject/SummonSearcher.php
+++ b/code/web/sys/SearchObject/SummonSearcher.php
@@ -507,7 +507,7 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 					if ($isApplied) {
 						$facetSettings['removalUrl'] = $this->renderLinkWithoutFilter($facetId . ':' . $facetValue);
 					} else {
-						$facetSettings['url'] = $this->renderSearchUrl() . '&filter[]=' . $facetId . ':' . urlencode($facetValue);
+						$facetSettings['url'] = $this->renderSearchUrl() . '&filter[]=' . $facetId . ':' . urlencode($facetValue) . '&page=1';
 					}
 					$list[] = $facetSettings;
 				}


### PR DESCRIPTION
Adjust code to ensure that if not on page one of result when a facet filter is applied, the filtered results dispaly from page one. Also addresses error where if you are on a result higher than the number of results available in a certain facet filter and apply the filter it does not work.